### PR TITLE
fixed delete car dialog to be destructive

### DIFF
--- a/src/features/cars/components/delete-car-dialog.tsx
+++ b/src/features/cars/components/delete-car-dialog.tsx
@@ -48,6 +48,7 @@ export default function DeleteCarDialog({
 						Cancel
 					</AlertDialogCancel>
 					<AlertDialogAction
+					    className="bg-destructive text-white hover:bg-destructive/90"
 						onClick={handleDelete}
 						disabled={deleteCarMutation.isPending}
 					>


### PR DESCRIPTION
Closes #26 

####Changes
--Updated delete car dialog button color to 'destructive'

<img width="1920" height="1080" alt="Screenshot (467)" src="https://github.com/user-attachments/assets/a642a6f9-5853-49cb-843e-35ebfa8d1d86" />
<img width="1920" height="1080" alt="Screenshot (466)" src="https://github.com/user-attachments/assets/76e3c18d-7879-432c-b9e0-d635f86ffb78" />
<img width="1920" height="1080" alt="Screenshot (465)" src="https://github.com/user-attachments/assets/2e79f0cc-de26-4115-9c07-7740f84e5af0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the visual styling of the Delete button with improved destructive state indication and hover effects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->